### PR TITLE
完善select选择框不能填写options内容的问题

### DIFF
--- a/src/components/AppType.vue
+++ b/src/components/AppType.vue
@@ -94,12 +94,24 @@ export default {
           }
         }
       }
+      if (data.isHideOptions !== false && data.options) {
+        formDesc.options = {
+          label: '选项',
+          type: 'json-editor',
+          attrs: {
+            height: '200px'
+          }
+        }
+      }
       data.formDesc = formDesc
       data.formData = {
         field: data.field,
         type: data.type,
         label: data.label,
         default: data.default
+      }
+      if (data.isHideOptions !== false && data.options) {
+        data.formData.options = data.options
       }
       return data
     }


### PR DESCRIPTION
[官网](https://dream2023.gitee.io/vue-ele-form-generator/)给的示例图：
编辑 select 选择框的options不能进行编辑。
